### PR TITLE
Feat/support key with passphrase

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+Dockerfile
+LICENSE
+*.md
+.git*

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,7 @@ RUN rm -rf /var/cache/apk/*
 RUN mkdir ~/.ssh
 
 # Copy in our executables.
-COPY agent-start agent-stop agent-add agent-autostart /bin/
-COPY hosts-clear hosts-add /bin/
+COPY agent-* hosts-* /bin/
 RUN chmod +x /bin/agent-* /bin/hosts-*
 
 # Prepare for known hosts.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ It takes one optional argument, for the name of the agent to be stopped. Default
 #### agent-add
 This command adds a key to the currently running SSH agent. The key is taken from stdin, and the agent used is that in SSH_AGENT_PID.
 
-#### agent-autoadd
+#### agent-autostart
 This command starts the SSH agent and loads the private key from the "SSH_PRIVATE_KEY" environment var. The command takes one optional argument, for the name of the agent to be started. Defaults to "default".
 As with agent-start, this command needs to be sourced.
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ This command adds a key to the currently running SSH agent. The key is taken fro
 This command starts the SSH agent and loads the private key from the "SSH_PRIVATE_KEY" environment var. The command takes one optional argument, for the name of the agent to be started. Defaults to "default".
 As with agent-start, this command needs to be sourced.
 
+#### agent-askpass
+This command is called by ssh-add when the [SSH_ASKPASS](https://man.openbsd.org/ssh-add.1#ENVIRONMENT) variable is set active. The command returns the SSH_PASS to [ssh-askpass(1)](https://man.openbsd.org/ssh-askpass.1).
+
+This command is ignored by ssh-add if the key does not require a passphrase.
+
 ### known_hosts management
 #### hosts-clear
 This command truncates the known_hosts file and sets its permissions.
@@ -77,4 +82,12 @@ deploy:
   stage: deploy
   script:
     - rsync -zrSlhaO --chmod=D2775,F664 --delete-after . $FTP_USER@$FTP_HOST:/var/www/deployment/
+```
+
+## Using with passphrase protected key
+
+You can supply a passphrase with ``SSH_PASS`` to ``agent-add``, ``agent-start`` or ``agent-autostart``.
+
+```
+SSH_PASS="THE_PASSPHRASE" agent-add
 ```

--- a/agent-add
+++ b/agent-add
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 source agent-start "${1:-default}"
-cat - | tr -d '\r' | ssh-add - >/dev/null
+cat - | tr -d '\r' | DISPLAY=1 SSH_ASKPASS=agent-askpass ssh-add - >/dev/null

--- a/agent-askpass
+++ b/agent-askpass
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo "$SSH_PASS"


### PR DESCRIPTION
Introduces a new command called ``agent-askpass`` and extends the behaviour of ``agent-add``:

### agent-askpass
This command is called by ssh-add when the [SSH_ASKPASS](https://man.openbsd.org/ssh-add.1#ENVIRONMENT) variable is set active. The command returns the SSH_PASS to [ssh-askpass(1)](https://man.openbsd.org/ssh-askpass.1).

This command is ignored by ssh-add if the key does not require a passphrase.

#### Using with passphrase protected key

You can supply a passphrase with ``SSH_PASS`` to ``agent-add``, ``agent-start`` or ``agent-autostart``.

```
SSH_PASS="THE_PASSPHRASE" agent-add
```

----

Backward compatibility is provided. 
