### PR TITLE
chore: update alpine base image

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+tab_width = 4
+indent_size = 4
+indent_style = space
+max_line_length = 9999
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{yml,yaml}]
+tab_width = 2
+indent_size = 2

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: monthly

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11
+FROM alpine:3.14.1
 MAINTAINER Dr Internet <internet@limelightgaming.net>
 
 # Install RSync and Open SSH.


### PR DESCRIPTION
### Description

I noticed that the base image was a very outdated Alpine version, so I updated that and added a Dependabot config to always keep it up to date (monthly check, can be set to daily too but seemed too excessive).
Since I am a big fan of editorconfigs I also added that one, however I can always revert that commit if you want me to :wink: 

Side-note: since there is already CI to build the Image a regular vulnerability scan via the likes of the [Trivy Action](https://github.com/aquasecurity/trivy-action) could be an interesting thing too.

### Change(s)

* update base image from alpine 3.11 to 3.14.1 (latest)
* add dependabot to monthly check for newer alpine versions
* add editorconfig for easy uniform formatting

### Issue(s)

* n/a